### PR TITLE
fix(workouts): allow workouts to be null

### DIFF
--- a/HealthKit.ios.js
+++ b/HealthKit.ios.js
@@ -22,7 +22,7 @@ export default {
     return new Date(dateOfBirth);
   },
   addWorkout: ({ startDate, endDate, calories, distance, metadata }) =>
-    RNHealthKit.addWorkout(startDate, endDate, calories, distance, metadata),
+    RNHealthKit.addWorkout(startDate, endDate, calories, distance || -1, metadata),
   getWorkouts: async (startDate = null, endDate = null) => {
     const workouts = await RNHealthKit.getWorkouts(startDate, endDate);
     return workouts.map(convertWorkoutDates);
@@ -38,7 +38,7 @@ export default {
     RNHealthKit.deleteWorkoutsByMetadata(key, value),
   editWorkoutByMetadata: async (key, value, { startDate, endDate, calories, distance, metadata }) => {
     await RNHealthKit.deleteWorkoutsByMetadata(key, value);
-    await RNHealthKit.addWorkout(startDate, endDate, calories, distance, metadata);
+    await RNHealthKit.addWorkout(startDate, endDate, calories, distance || -1, metadata);
   },
   getWeights: async (unit, startDate, endDate) => {
     if (!unit) {

--- a/ios/react-native-healthkit/RCTHealthKit+Characteristics.m
+++ b/ios/react-native-healthkit/RCTHealthKit+Characteristics.m
@@ -46,7 +46,7 @@ typedef void(^ResultsHandler)(HKSampleQuery * _Nonnull query, NSArray<__kindof H
             reject:(RCTPromiseRejectBlock)reject{
     HKUnit *caloriesUnit = [HKUnit calorieUnit];
     HKQuantity *caloriesQuantity = [HKQuantity quantityWithUnit:caloriesUnit doubleValue:calories];
-    HKQuantity *distanceQuantity = [HKQuantity quantityWithUnit:HKUnit.meterUnit doubleValue:distance];
+    HKQuantity *distanceQuantity = distance != -1 ? [HKQuantity quantityWithUnit:HKUnit.meterUnit doubleValue:distance] : nil;
 
     HKWorkout *workout = [HKWorkout workoutWithActivityType:HKWorkoutActivityTypeOther
                                                   startDate:startDate


### PR DESCRIPTION
We'll send invalid values as -1 to the native realm. Since distances have to be natural numbers, we can consider -1 to be a representation of an empty value.