### PR TITLE
feat(RCTHealthKit+Characteristics): use kiloCalorie for calories

### DIFF
--- a/ios/react-native-healthkit/RCTHealthKit+Characteristics.m
+++ b/ios/react-native-healthkit/RCTHealthKit+Characteristics.m
@@ -44,7 +44,7 @@ typedef void(^ResultsHandler)(HKSampleQuery * _Nonnull query, NSArray<__kindof H
             metadata:(NSDictionary*)metadata
             resolve:(RCTPromiseResolveBlock)resolve
             reject:(RCTPromiseRejectBlock)reject{
-    HKUnit *caloriesUnit = [HKUnit calorieUnit];
+    HKUnit *caloriesUnit = [HKUnit kilocalorieUnit];
     HKQuantity *caloriesQuantity = [HKQuantity quantityWithUnit:caloriesUnit doubleValue:calories];
     HKQuantity *distanceQuantity = distance != -1 ? [HKQuantity quantityWithUnit:HKUnit.meterUnit doubleValue:distance] : nil;
 
@@ -236,7 +236,7 @@ typedef void(^ResultsHandler)(HKSampleQuery * _Nonnull query, NSArray<__kindof H
     }
     if([sample isKindOfClass:[HKWorkout class]]) {
         if ([((HKWorkout *)sample) totalEnergyBurned]) {
-            double calories = [[((HKWorkout *)sample) totalEnergyBurned] doubleValueForUnit:[HKUnit smallCalorieUnit]];
+            double calories = [[((HKWorkout *)sample) totalEnergyBurned] doubleValueForUnit:[HKUnit kilocalorieUnit]];
             dictionary[@"calories"] = [NSNumber numberWithFloat:calories];
         }
         if ([((HKWorkout *)sample) totalDistance]) {


### PR DESCRIPTION
Prior to this patch, the smallCalorieUnit was being used, which could cause a crash
on devices running iOS below 11 since it's not available. This commit changes to the
kiloCalorie unit which is supported by all iOS versions that our app supports