### PR TITLE
fix(HKActivityType): send the activity type as a parameter

### DIFF
--- a/HealthKit.ios.js
+++ b/HealthKit.ios.js
@@ -21,8 +21,8 @@ export default {
     const dateOfBirth = await RNHealthKit.getDateOfBirth();
     return new Date(dateOfBirth);
   },
-  addWorkout: ({ startDate, endDate, calories, distance, metadata }) =>
-    RNHealthKit.addWorkout(startDate, endDate, calories, distance || -1, metadata),
+  addWorkout: ({ activityType, startDate, endDate, calories, distance, metadata }) =>
+    RNHealthKit.addWorkout(activityType, startDate, endDate, calories, distance || -1, metadata),
   getWorkouts: async (startDate = null, endDate = null) => {
     const workouts = await RNHealthKit.getWorkouts(startDate, endDate);
     return workouts.map(convertWorkoutDates);
@@ -36,9 +36,9 @@ export default {
   },
   deleteWorkoutsByMetadata: (key, value) =>
     RNHealthKit.deleteWorkoutsByMetadata(key, value),
-  editWorkoutByMetadata: async (key, value, { startDate, endDate, calories, distance, metadata }) => {
+  editWorkoutByMetadata: async (key, value, { activityType, startDate, endDate, calories, distance, metadata }) => {
     await RNHealthKit.deleteWorkoutsByMetadata(key, value);
-    await RNHealthKit.addWorkout(startDate, endDate, calories, distance || -1, metadata);
+    await RNHealthKit.addWorkout(activityType, startDate, endDate, calories, distance || -1, metadata);
   },
   getWeights: async (unit, startDate, endDate) => {
     if (!unit) {

--- a/ios/react-native-healthkit/RCTHealthKit+Characteristics.h
+++ b/ios/react-native-healthkit/RCTHealthKit+Characteristics.h
@@ -10,7 +10,8 @@
 
 #pragma mark - Workouts
 
-- (void)_addWorkout:(NSDate*)startDate
+- (void)_addWorkout:(NSString*)activityType
+          startDate:(NSDate*)startDate
             endDate:(NSDate*)endDate
            calories:(float)calories
    distanceInMeters:(float)distance

--- a/ios/react-native-healthkit/RCTHealthKit+Characteristics.m
+++ b/ios/react-native-healthkit/RCTHealthKit+Characteristics.m
@@ -1,6 +1,7 @@
 #import "RCTHealthKit+Characteristics.h"
 #import "RCTHealthKit+Utils.h"
 #import <React/RCTConvert.h>
+#import "RCTHealthKitDataModels.h"
 
 typedef void(^ResultsHandler)(HKSampleQuery * _Nonnull query, NSArray<__kindof HKSample *> * _Nullable results, NSError * _Nullable error);
 
@@ -37,18 +38,20 @@ typedef void(^ResultsHandler)(HKSampleQuery * _Nonnull query, NSArray<__kindof H
 
 #pragma mark - Workouts
 
-- (void)_addWorkout:(NSDate*)startDate
+- (void)_addWorkout:(NSString*)activityType
+          startDate:(NSDate*)startDate
             endDate:(NSDate*)endDate
-            calories:(float)calories
+           calories:(float)calories
    distanceInMeters:(float)distance
-            metadata:(NSDictionary*)metadata
+           metadata:(NSDictionary*)metadata
             resolve:(RCTPromiseResolveBlock)resolve
-            reject:(RCTPromiseRejectBlock)reject{
+             reject:(RCTPromiseRejectBlock)reject{
     HKUnit *caloriesUnit = [HKUnit kilocalorieUnit];
     HKQuantity *caloriesQuantity = [HKQuantity quantityWithUnit:caloriesUnit doubleValue:calories];
     HKQuantity *distanceQuantity = distance != -1 ? [HKQuantity quantityWithUnit:HKUnit.meterUnit doubleValue:distance] : nil;
-
-    HKWorkout *workout = [HKWorkout workoutWithActivityType:HKWorkoutActivityTypeOther
+    HKWorkoutActivityType type = [RCTHealthKitDataModels.workoutsDict objectForKey:activityType] ? [RCTHealthKitDataModels.workoutsDict[activityType] intValue] : HKWorkoutActivityTypeOther;
+    
+    HKWorkout *workout = [HKWorkout workoutWithActivityType:type
                                                   startDate:startDate
                                                     endDate:endDate
                                                    duration:0
@@ -56,7 +59,7 @@ typedef void(^ResultsHandler)(HKSampleQuery * _Nonnull query, NSArray<__kindof H
                                               totalDistance:distanceQuantity
                                                      device:nil
                                                    metadata:metadata];
-
+    
     [self._healthStore saveObject:workout withCompletion:^(BOOL success, NSError * _Nullable error) {
         if(!success) {
             reject(@"RCTHealthKit_save_workout_fail", @"An error occurred while saving the workout", error);

--- a/ios/react-native-healthkit/RCTHealthKit.m
+++ b/ios/react-native-healthkit/RCTHealthKit.m
@@ -84,7 +84,8 @@ RCT_EXPORT_METHOD(getDateOfBirth:(RCTPromiseResolveBlock)resolve rejecter:(RCTPr
 
 #pragma mark - Workouts
 
-RCT_EXPORT_METHOD(addWorkout:(NSDate*)startDate
+RCT_EXPORT_METHOD(addWorkout:(NSString*)activityType
+                  startDate:(NSDate*)startDate
                   endDate:(NSDate*)endDate
                   calories:(float)calories
           distanceInMeters:(float)distance
@@ -92,7 +93,8 @@ RCT_EXPORT_METHOD(addWorkout:(NSDate*)startDate
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject) {
     [self _initializeHealthStore];
-    [self _addWorkout:startDate 
+    [self _addWorkout:activityType
+            startDate:startDate
               endDate:endDate
              calories:calories
      distanceInMeters:distance

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-healthkit",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Native Module bridge for the Apple Health Kit",
   "main": "index.js",
   "bugs": {


### PR DESCRIPTION
- required for this PR in Equinox App - https://bitbucket.org/equinoxfitness/equinox-react-native-porting/pull-requests/1911/chore-applehealthsubcategorymapping-map-eq/diff
- when syncing workouts from Equinox to healthKit also set the activity type
- fix issue that all activities imported in HK were imported as "Other"